### PR TITLE
Fedora 15 installation issue

### DIFF
--- a/ext/noderb_extension/extconf.rb
+++ b/ext/noderb_extension/extconf.rb
@@ -1,6 +1,7 @@
 require "mkmf"
 
 cflags = " -shared -fPIC "
+cppflags = "-fPIC"
 
 if $solaris
   cflags = " -G -fPIC "
@@ -14,7 +15,7 @@ end
 
 $CFLAGS = CONFIG['CFLAGS'] = cflags
 
-`cd libuv; CFLAGS="#{cflags}" make; cd ..; cp libuv/uv.a libuv.a`
+`cd libuv; CFLAGS="#{cflags}" CPPFLAGS=#{cppflags} make; cd ..; cp libuv/uv.a libuv.a`
 
 dir_config("uv", File.expand_path("../libuv/include", __FILE__), File.expand_path("../libuv", __FILE__))
 

--- a/ext/noderb_extension/libuv/Makefile
+++ b/ext/noderb_extension/libuv/Makefile
@@ -24,7 +24,7 @@ ifdef MSVC
 uname_S := MINGW
 endif
 
-CPPFLAGS += -Iinclude -Iinclude/uv-private -fPIC
+CPPFLAGS += -Iinclude -Iinclude/uv-private
 
 CARES_OBJS =
 CARES_OBJS += src/ares/ares__close_sockets.o

--- a/ext/noderb_extension/libuv/Makefile
+++ b/ext/noderb_extension/libuv/Makefile
@@ -24,7 +24,7 @@ ifdef MSVC
 uname_S := MINGW
 endif
 
-CPPFLAGS += -Iinclude -Iinclude/uv-private
+CPPFLAGS += -Iinclude -Iinclude/uv-private -fPIC
 
 CARES_OBJS =
 CARES_OBJS += src/ares/ares__close_sockets.o


### PR DESCRIPTION
When trying to compile no Fedora 15, the followin error occured:

/usr/bin/ld: ./libuv.a(core.o): relocation R_X86_64_32S against `.rodata'
can not be used when making a shared object; recompile with -fPIC

Adding -fPIC to libuv Makefile fixed the error and the compilation
worked successfully
